### PR TITLE
Add back some features from gist

### DIFF
--- a/lib/sinatra/partial.rb
+++ b/lib/sinatra/partial.rb
@@ -5,24 +5,61 @@ require 'sinatra/base'
 module Sinatra
   module Partial
     
-    # support for partials
-    # @example
-    #   partial( :meta, :locals => {meta: meta} )
-    def partial(template, *args)
-      opts = args.last.is_a?(Hash) ? args.pop : {} # get hash options if they're there
-      opts.merge!(:layout => false) # don't layout, this is a partial
+    # Renders a partial to a string
+    # 
+    # @param [#to_s] partial the partial to render
+    # @param [Hash] options the options to render the partial with
+    # @option options [Hash] :locals local variables to render with
+    # @option options [Array] :collection renders the template once per object in this array
+    # @option options [Symbol] :template_engine the template engine to use. Haml by default
+    #
+    # @return [String] the rendered template contents
+    #
+    # @example simply render a partial
+    #   partial(:meta, :locals => {meta: meta})
+    #     # => renders views/_meta.haml
+    #
+    # @example render a partial in a subfolder
+    #   partial("meta/news", :locals => {news: [<News>]})
+    #     # => renders views/meta/_news.haml
+    #
+    # @example render a collection of objects with one partial
+    #   partial(:"meta/news", :collection => [<News>])
+    #     # => renders views/meta/_news.haml once per item in :collection,
+    #           with the local variable `news` being the current item in the iteration
+    #
+    # @see https://gist.github.com/119874
+    def partial(partial, options={})
+      partial_location = partial.to_s
+      
+      locals = options.fetch(:locals, {})
+      engine = options.fetch(:template_engine, :haml)
+      
+      template = partial_expand_path(partial_location)
+      
+      if collection = options.delete(:collection)
+        member_local = partial_local(partial_location)
 
-      if collection = opts.delete(:collection)
-        locals = opts[:locals].nil? ? {} : opts.delete(:locals)
         collection.inject([]) do |buffer, member|
-          buffer << haml( template, opts.merge(:layout => false, :locals => {template.to_sym => member}.merge(locals)
-            )
-          )
+          new_locals = {member_local => member}.merge(locals)
+          buffer << self.method(engine).call(template, options.merge(:locals => new_locals))
         end.join("\n")
       else
-        haml(template, opts)
+        self.method(engine).call(template, options)
       end
-    end # def
+    end
+    
+    private
+    
+    def partial_expand_path(partial_path)
+      parts = partial_path.split("/")
+      parts.last.insert(0, "_")
+      parts.join("/").to_sym
+    end
+    
+    def partial_local(partial_path)
+      name.split("/").last.to_sym
+    end
   end
 
   helpers Partial


### PR DESCRIPTION
The most requested feature is the ability to configure the template renderer. I've added that with the `:template_engine` option.

Another feature I'm keen to put back in is the ability to nest partials inside folders, and the rails convention of an underscore before the start of the name.

I also cleared up various things that no longer make sense, like the `*args` argument that only ever accepted options or things like merging :layout => false (which is no longer needed according to @rkh)

If I get time, I'll add a configurable option to set the partial template engine in your app configuration rather than at call-time, but this will do for the moment.
